### PR TITLE
Display more information about deployment based on description

### DIFF
--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -58,7 +58,7 @@ const buildJiraPayload = (associations) => {
 			schemaVersion: "1.0",
 			deploymentSequenceNumber: 1234,
 			updateSequenceNumber: 123456,
-			displayName: "deploy",
+			displayName: "foo42",
 			url: "test-repo-url/commit/885bee1-commit-id-1c458/checks",
 			description: "deploy",
 			lastUpdated: new Date("2021-06-28T12:15:18.000Z"),

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -290,7 +290,7 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 			schemaVersion: "1.0",
 			deploymentSequenceNumber: deployment.id,
 			updateSequenceNumber: deployment_status.id,
-			displayName: deployment.task,
+			displayName: deployment.description || deployment_status.description,
 			url: deployment_status.target_url || deployment.url,
 			description: deployment.description || deployment_status.description || deployment.task,
 			lastUpdated: new Date(deployment_status.updated_at),

--- a/test/fixtures/deployment_status-basic.json
+++ b/test/fixtures/deployment_status-basic.json
@@ -9,7 +9,7 @@
 				"login": "TestUser[bot]",
 				"type": "Bot"
 			},
-			"description": "",
+			"description": "Last deploy status desc on production",
 			"environment": "Production",
 			"target_url": "test-repo-url/commit/885bee1-commit-id-1c458/checks",
 			"environment_url": "https://test-repo-url.env-production.company.io",
@@ -21,7 +21,7 @@
 			"task": "deploy",
 			"original_environment": "Production",
 			"environment": "Production",
-			"description": "",
+			"description": "Deploying X on production",
 			"created_at": "2021-06-28T12:15:18Z",
 			"updated_at": "2021-06-28T12:15:18Z",
 			"creator": {

--- a/test/fixtures/deployment_status_staging.json
+++ b/test/fixtures/deployment_status_staging.json
@@ -9,7 +9,7 @@
 				"login": "TestUser[bot]",
 				"type": "Bot"
 			},
-			"description": "",
+			"description": "Last deploy status desc on foo42",
 			"environment": "foo42",
 			"target_url": "test-repo-url/commit/885bee1-commit-id-1c458/checks",
 			"environment_url": "https://test-repo-url.env-foo.company.io",
@@ -21,7 +21,7 @@
 			"task": "deploy",
 			"original_environment": "foo42",
 			"environment": "foo42",
-			"description": "",
+			"description": "Deploying X on foo42",
 			"created_at": "2021-06-28T12:15:18Z",
 			"updated_at": "2021-06-28T12:15:18Z",
 			"creator": {


### PR DESCRIPTION
As mentioned in [Github documentation](https://docs.github.com/en/rest/deployments/deployments#about-the-deployments-api):
> Deployment statuses can also include an optional description and log_url, which are highly recommended because they make deployment statuses more useful.

We want to avoid having duplicate information between "pipeline" and
"deployments" and use the more rich informations provided on
description.

<img width="1060" alt="d-11-10_à_15_11_10" src="https://user-images.githubusercontent.com/8417720/201163417-63791bb1-18db-4324-ab4c-32c6a1e7a165.png">

For people who use the classic Github Action to mark deployment as suggested by Jira. It's here:

https://github.com/chrnorm/deployment-action/blob/880668c419e283adc6b1cc092d52eb5e558fec4d/action.yml#L24-L26

To do :
  - [ ] Make test pass

Related:
  - https://github.com/atlassian/github-for-jira/issues/1536
  - https://github.com/atlassian/github-for-jira/pull/1732
  - https://github.com/atlassian/github-for-jira/pull/1736